### PR TITLE
Add helper to easily discard consumed entries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,14 @@ impl Consumer {
         Ok(())
     }
 
+    pub async fn discard_consumed(&mut self) -> Result<()> {
+        let consumers = self.consumers().await?;
+        if let Some(min_ver) = consumers.into_iter().map(|(_, v)| v).min() {
+            self.discard_upto(min_ver).await?;
+        }
+        Ok(())
+    }
+
     pub async fn consumers(&mut self) -> Result<BTreeMap<String, Version>> {
         let t = self.client.transaction().await?;
         let rows = t.query(LIST_CONSUMERS, &[]).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@ static IS_VISIBLE: &'static str = "\
     SELECT $1 < xmin as lt_xmin, xmin, current FROM snapshot";
 static DISCARD_ENTRIES: &'static str = "DELETE FROM logs WHERE (tx_id, id) <= ($1, $2)";
 
-static UPSERT_CONSUMER_OFFSET: &'static str =
-    "INSERT INTO log_consumer_positions (name, \
+static UPSERT_CONSUMER_OFFSET: &'static str = "INSERT INTO log_consumer_positions (name, \
      tx_position, position) values ($1, $2, $3) ON CONFLICT (name) DO \
      UPDATE SET tx_position = EXCLUDED.tx_position, position = EXCLUDED.position";
 static FETCH_CONSUMER_POSITION: &'static str =

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -784,6 +784,7 @@ async fn can_discard_consumed() {
             .await
             .expect("wait for version");
         let entry = cons.poll().await.expect("poll").expect("some entry");
+        assert_eq!(String::from_utf8_lossy(&entry.data), "0");
         cons.commit_upto(&entry).await.expect("commit");
     }
 
@@ -793,6 +794,11 @@ async fn can_discard_consumed() {
             .await
             .expect("consumer");
         cons.discard_consumed().await.expect("discard");
+
+        println!(
+            "Consumers: {:#?}",
+            cons.consumers().await.expect("consumers")
+        );
     }
 
     {
@@ -801,7 +807,7 @@ async fn can_discard_consumed() {
             .await
             .expect("consumer");
         let entry = cons.poll().await.expect("poll").expect("some entry");
-        assert_eq!(&entry.data, b"1");
+        assert_eq!(String::from_utf8_lossy(&entry.data), "1");
     }
 }
 


### PR DESCRIPTION
Otherwise, we'd need to use `discard_upto` ourselves with the right version.