### PR TITLE
Handle transaction id resets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,8 +414,8 @@ impl Consumer {
         Ok(())
     }
 
-    pub async fn consumers(&mut self) -> Result<BTreeMap<String, Version>> {
-        let t = self.client.transaction().await?;
+    pub async fn consumers(client: &mut Client) -> Result<BTreeMap<String, Version>> {
+        let t = client.transaction().await?;
         let rows = t.query(LIST_CONSUMERS, &[]).await?;
 
         let consumers = rows

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ static FETCH_NEXT_ROW: &str = "\
     FROM logs
     WHERE (tx_id, id) > ($1, $2)
     AND tx_id < txid_snapshot_xmin(txid_current_snapshot())
+    ORDER BY (tx_id, id)
     LIMIT $3";
 static IS_VISIBLE: &str = "\
     WITH snapshot as (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,20 +13,30 @@ use tokio::{
     sync::Notify,
     time::{sleep, Duration},
 };
-use tokio_postgres::{self, AsyncMessage, Client, Connection};
+use tokio_postgres::{self, AsyncMessage, Client, Connection, Transaction};
 
 const LIMIT_BUFFER: i64 = 1024;
 
+// In our SQL, the "current epoch" is defined as either:
+// 1 if is_empty(log)
+// log_head.epoch if log_head.epoch.tx_id < txid_current()
+// log_head.epoch otherwise
+
 static INSERT_ROW_SQL: &str =
-    "INSERT INTO logs (key, body) values($1, $2) RETURNING tx_id as tx_position, id as position";
+    "INSERT INTO logs (epoch, key, body) values($1, $2, $3) RETURNING epoch, tx_id as tx_position, id as position";
+static SAMPLE_HEAD: &str = "\
+    SELECT epoch, tx_id, txid_current() as current_tx_id
+    FROM logs ORDER BY (epoch, tx_id) desc
+    LIMIT 1";
 static SEND_NOTIFY_SQL: &str = "SELECT pg_notify('logs', '')";
+
 static FETCH_NEXT_ROW: &str = "\
-    SELECT tx_id as tx_position, id as position, key, body, written_at
+    SELECT epoch, tx_id as tx_position, id as position, key, body, written_at
     FROM logs
-    WHERE (tx_id, id) > ($1, $2)
-    AND tx_id < txid_snapshot_xmin(txid_current_snapshot())
-    ORDER BY (tx_id, id)
-    LIMIT $3";
+    WHERE (epoch, tx_id, id) > ($1, $2, $3)
+    AND (epoch, tx_id) < ($4, txid_snapshot_xmin(txid_current_snapshot()))
+    ORDER BY (epoch, tx_id, id)
+    LIMIT $5";
 static IS_VISIBLE: &str = "\
     WITH snapshot as (
         select txid_snapshot_xmin(txid_current_snapshot()) as xmin,
@@ -35,13 +45,16 @@ static IS_VISIBLE: &str = "\
     SELECT $1 < xmin as lt_xmin, xmin, current FROM snapshot";
 static DISCARD_ENTRIES: &str = "DELETE FROM logs WHERE (tx_id, id) <= ($1, $2)";
 
-static UPSERT_CONSUMER_OFFSET: &str = "INSERT INTO log_consumer_positions (name, \
-     tx_position, position) values ($1, $2, $3) ON CONFLICT (name) DO \
+static UPSERT_CONSUMER_OFFSET: &str = "\
+     INSERT INTO log_consumer_positions (name, epoch, tx_position, position) \
+     values ($1, $2, $3, $4) \
+     ON CONFLICT (name) DO \
      UPDATE SET tx_position = EXCLUDED.tx_position, position = EXCLUDED.position";
 static FETCH_CONSUMER_POSITION: &str =
-    "SELECT tx_position, position FROM log_consumer_positions WHERE \
+    "SELECT epoch, tx_position, position FROM log_consumer_positions WHERE \
      name = $1";
-static LIST_CONSUMERS: &str = "SELECT name, tx_position, position FROM log_consumer_positions";
+static LIST_CONSUMERS: &str =
+    "SELECT name, epoch, tx_position, position FROM log_consumer_positions";
 static DISCARD_CONSUMER: &str = "DELETE FROM log_consumer_positions WHERE name = $1";
 static CREATE_TABLE_SQL: &str = include_str!("schema.sql");
 
@@ -49,6 +62,7 @@ static LISTEN: &str = "LISTEN logs";
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Version {
+    pub epoch: i64,
     pub tx_id: i64,
     pub seq: i64,
 }
@@ -87,6 +101,7 @@ pub async fn setup(conn: &Client) -> Result<()> {
 pub struct Batch<'a> {
     transaction: tokio_postgres::Transaction<'a>,
     insert: tokio_postgres::Statement,
+    epoch: i64,
 }
 
 pub async fn produce(client: &mut Client, key: &[u8], body: &[u8]) -> Result<Version> {
@@ -98,16 +113,40 @@ pub async fn produce(client: &mut Client, key: &[u8], body: &[u8]) -> Result<Ver
 
 pub async fn batch(client: &mut Client) -> Result<Batch<'_>> {
     let t = client.transaction().await?;
+    let epoch = current_epoch(&t).await?;
     let insert = t.prepare(INSERT_ROW_SQL).await?;
     Ok(Batch {
         transaction: t,
         insert,
+        epoch,
     })
+}
+
+async fn current_epoch(t: &Transaction<'_>) -> Result<i64> {
+    if let Some(epoch_row) = t.query_opt(SAMPLE_HEAD, &[]).await? {
+        let head_epoch: i64 = epoch_row.get("epoch");
+        let head_tx_id: i64 = epoch_row.get("tx_id");
+        let current_tx_id: i64 = epoch_row.get("current_tx_id");
+        if current_tx_id >= head_tx_id {
+            return Ok(head_epoch);
+        } else {
+            warn!(
+                "Running behind in epoch {:?}? {:?} > {:?}",
+                head_epoch, current_tx_id, head_tx_id
+            );
+            return Ok(head_epoch + 1);
+        }
+    };
+
+    Ok(1)
 }
 
 impl<'a> Batch<'a> {
     pub async fn produce(&self, key: &[u8], body: &[u8]) -> Result<Version> {
-        let rows = self.transaction.query(&self.insert, &[&key, &body]).await?;
+        let rows = self
+            .transaction
+            .query(&self.insert, &[&self.epoch, &key, &body])
+            .await?;
         let id = rows
             .iter()
             .map(|r| Version::from_row(r))
@@ -229,12 +268,16 @@ impl Consumer {
         }
 
         let t = self.client.transaction().await?;
+        let epoch = current_epoch(&t).await?;
+
         let rows = t
             .query(
                 FETCH_NEXT_ROW,
                 &[
+                    &self.last_seen_offset.epoch,
                     &self.last_seen_offset.tx_id,
                     &self.last_seen_offset.seq,
+                    &epoch,
                     &LIMIT_BUFFER,
                 ],
             )
@@ -335,7 +378,12 @@ impl Consumer {
         let t = self.client.transaction().await?;
         t.execute(
             UPSERT_CONSUMER_OFFSET,
-            &[&self.name, &entry.version.tx_id, &entry.version.seq],
+            &[
+                &self.name,
+                &entry.version.epoch,
+                &entry.version.tx_id,
+                &entry.version.seq,
+            ],
         )
         .await?;
         t.commit().await?;
@@ -396,6 +444,7 @@ impl fmt::Debug for Consumer {
 impl Version {
     fn from_row(row: &tokio_postgres::Row) -> Self {
         Version {
+            epoch: row.get("epoch"),
             tx_id: row.get("tx_position"),
             seq: row.get("position"),
         }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -81,3 +81,6 @@ DO $$
         END IF;
     END
 $$;
+
+CREATE INDEX IF NOT EXISTS logs_epoch_offset_idx ON logs(epoch, tx_id, id);
+DROP INDEX IF EXISTS logs_offset_idx;

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -49,3 +49,35 @@ DO $$
         END IF;
     END
 $$;
+
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT true FROM pg_attribute
+            WHERE attrelid = 'logs'::regclass
+            AND attname = 'epoch'
+            AND NOT attisdropped
+        ) THEN
+            -- BEGIN;
+            ALTER TABLE logs ADD COLUMN epoch BIGINT;
+            UPDATE logs SET epoch = 1 where epoch IS NULL;
+            ALTER TABLE logs ALTER COLUMN epoch SET NOT NULL;
+            -- COMMIT;
+        END IF;
+    END
+$$;
+
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT true FROM pg_attribute
+            WHERE attrelid = 'log_consumer_positions'::regclass
+            AND attname = 'epoch'
+            AND NOT attisdropped
+        ) THEN
+            ALTER TABLE log_consumer_positions ADD COLUMN epoch BIGINT;
+            UPDATE log_consumer_positions SET epoch = 1 where epoch IS NULL;
+            ALTER TABLE log_consumer_positions ALTER COLUMN epoch SET NOT NULL;
+        END IF;
+    END
+$$;

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -8,10 +8,10 @@ use futures::{
 use tokio_postgres::{self, Client, Connection, NoTls};
 
 use anyhow::{Error, Result};
-use std::collections::BTreeMap;
 use std::env;
 use std::thread;
 use std::time;
+use std::{cmp, collections::BTreeMap};
 
 const DEFAULT_URL: &str = "postgres://postgres@localhost/";
 
@@ -1130,4 +1130,52 @@ async fn can_batch_produce_pipelined() {
     }
 
     assert_eq!(items, observed);
+}
+
+#[tokio::test]
+async fn can_batch_produce_concurrently_with_wall_clock_order() {
+    env_logger::try_init().unwrap_or(());
+    setup("can_batch_produce_concurrently").await;
+
+    let (mut client1, conn) = connect("can_batch_produce_concurrently")
+        .await
+        .expect("connect");
+    tokio::spawn(conn);
+
+    let (mut client2, conn) = connect("can_batch_produce_concurrently")
+        .await
+        .expect("connect");
+    tokio::spawn(conn);
+
+    let batch1 = pg_queue::batch(&mut client1).await.expect("batch");
+    let batch2 = pg_queue::batch(&mut client2).await.expect("batch");
+
+    batch1.produce(b"a", b"1").await.expect("produce");
+    batch2.produce(b"b", b"2").await.expect("produce");
+    let v1 = batch1.produce(b"a", b"3").await.expect("produce");
+    let v2 = batch2.produce(b"b", b"4").await.expect("produce");
+
+    batch1.commit().await.expect("commit");
+    batch2.commit().await.expect("commit");
+
+    println!("Versions: {:?} / {:?}", v1, v2);
+
+    let (client, conn) = connect("can_batch_produce_concurrently")
+        .await
+        .expect("connect");
+    let mut cons = pg_queue::Consumer::new(conn, client, "default")
+        .await
+        .expect("consumer");
+
+    cons.wait_until_visible(cmp::max(v1, v2), time::Duration::from_secs(1))
+        .await
+        .expect("wait for version");
+
+    let mut observed = Vec::new();
+
+    while let Some(item) = cons.poll().await.expect("item") {
+        observed.push(String::from_utf8(item.data).expect("from utf8"));
+    }
+
+    assert_eq!(vec!["1", "2", "3", "4"], observed);
 }

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -885,6 +885,11 @@ async fn can_discard_consumed_without_losing_entries() {
         let mut cons = pg_queue::Consumer::new(conn, client, "two")
             .await
             .expect("consumer");
+
+        cons.wait_until_visible(v2, time::Duration::from_secs(1))
+            .await
+            .expect("wait for version");
+
         let _ = cons.poll().await.expect("poll").expect("some entry");
         let _ = cons.poll().await.expect("poll").expect("some entry");
         let entry = cons.poll().await.expect("poll").expect("some entry");

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -1084,9 +1084,9 @@ async fn can_read_timestamp() {
 }
 
 #[tokio::test]
-async fn can_batch_produce_concurrently() {
+async fn can_batch_produce_pipelined() {
     env_logger::try_init().unwrap_or(());
-    let schema = "can_batch_produce_concurrently";
+    let schema = "can_batch_produce_pipelined";
     setup(schema).await;
 
     let (client, conn) = connect(schema).await.expect("connect");

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -101,9 +101,10 @@ async fn setup(schema: &str) {
 #[tokio::test]
 async fn can_produce_none() {
     env_logger::try_init().unwrap_or(());
-    setup("can_produce_none").await;
+    let schema = "can_produce_none";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_produce_none").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     debug!("setup consumer");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
@@ -115,14 +116,15 @@ async fn can_produce_none() {
 #[tokio::test]
 async fn can_produce_one() {
     env_logger::try_init().unwrap_or(());
-    setup("can_produce_one").await;
-    let (client, conn) = connect("can_produce_one").await.expect("connect");
+    let schema = "can_produce_one";
+    setup(schema).await;
+    let (client, conn) = connect(schema).await.expect("connect");
 
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
 
-    let (mut client, conn) = connect("can_produce_one").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     let v = pg_queue::produce(&mut client, b"foo", b"42")
@@ -152,14 +154,15 @@ async fn can_produce_one() {
 #[tokio::test]
 async fn can_produce_several() {
     env_logger::try_init().unwrap_or(());
-    setup("can_produce_several").await;
+    let schema = "can_produce_several";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_produce_several").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
 
-    let (mut client, conn) = connect("can_produce_several").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     pg_queue::produce(&mut client, b"a", b"0")
@@ -193,9 +196,10 @@ async fn can_produce_several() {
 #[tokio::test]
 async fn can_produce_ordered() {
     env_logger::try_init().unwrap_or(());
-    setup("can_produce_ordered").await;
+    let schema = "can_produce_ordered";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_produce_ordered").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     let v0 = pg_queue::produce(&mut client, b"a", b"0")
@@ -215,14 +219,15 @@ async fn can_produce_ordered() {
 #[tokio::test]
 async fn can_produce_in_batches() {
     env_logger::try_init().unwrap_or(());
-    setup("can_produce_in_batches").await;
+    let schema = "can_produce_in_batches";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_produce_in_batches").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
 
-    let (mut client, conn) = connect("can_produce_in_batches").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     let v = {
@@ -255,14 +260,15 @@ async fn can_produce_in_batches() {
 #[tokio::test]
 async fn can_rollback_batches() {
     env_logger::try_init().unwrap_or(());
-    setup("can_rollback_batches").await;
+    let schema = "can_rollback_batches";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_rollback_batches").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
 
-    let (mut client, conn) = connect("can_rollback_batches").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     let v = {
@@ -283,9 +289,10 @@ async fn can_rollback_batches() {
 #[tokio::test]
 async fn can_produce_incrementally() {
     env_logger::try_init().unwrap_or(());
-    setup("can_produce_incrementally").await;
+    let schema = "can_produce_incrementally";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_produce_incrementally").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     pg_queue::produce(&mut client, b"a", b"0")
@@ -298,7 +305,7 @@ async fn can_produce_incrementally() {
         .await
         .expect("produce");
 
-    let (client, conn) = connect("can_produce_incrementally").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
@@ -317,9 +324,10 @@ async fn can_produce_incrementally() {
 #[tokio::test]
 async fn can_consume_incrementally() {
     env_logger::try_init().unwrap_or(());
-    setup("can_consume_incrementally").await;
+    let schema = "can_consume_incrementally";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_consume_incrementally").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     pg_queue::produce(&mut client, b"key", b"0")
@@ -343,7 +351,7 @@ async fn can_consume_incrementally() {
     for i in 0..expected.len() {
         debug!("Creating consumer iteration {}", i);
         let mut cons = {
-            let (client, conn) = connect("can_consume_incrementally").await.expect("connect");
+            let (client, conn) = connect(schema).await.expect("connect");
             pg_queue::Consumer::new(conn, client, "default")
                 .await
                 .expect("consumer")
@@ -365,11 +373,10 @@ async fn can_consume_incrementally() {
 #[tokio::test]
 async fn can_restart_consume_at_commit_point() {
     env_logger::try_init().unwrap_or(());
-    setup("can_restart_consume_at_commit_point").await;
+    let schema = "can_restart_consume_at_commit_point";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_restart_consume_at_commit_point")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -382,9 +389,7 @@ async fn can_restart_consume_at_commit_point() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_restart_consume_at_commit_point")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -399,9 +404,7 @@ async fn can_restart_consume_at_commit_point() {
     }
 
     {
-        let (client, conn) = connect("can_restart_consume_at_commit_point")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -409,9 +412,7 @@ async fn can_restart_consume_at_commit_point() {
         assert_eq!(entry.map(|e| e.data), Some(b"1".to_vec()));
     }
     {
-        let (client, conn) = connect("can_restart_consume_at_commit_point")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -423,11 +424,10 @@ async fn can_restart_consume_at_commit_point() {
 #[tokio::test]
 async fn can_progress_without_commit() {
     env_logger::try_init().unwrap_or(());
-    setup("can_progress_without_commit").await;
+    let schema = "can_progress_without_commit";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_progress_without_commit")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     pg_queue::produce(&mut client, b"key", b"0")
@@ -441,9 +441,7 @@ async fn can_progress_without_commit() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_progress_without_commit")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -460,9 +458,10 @@ async fn can_progress_without_commit() {
 #[tokio::test]
 async fn can_consume_multiply() {
     env_logger::try_init().unwrap_or(());
-    setup("can_consume_multiply").await;
+    let schema = "can_consume_multiply";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_consume_multiply").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     pg_queue::produce(&mut client, b"key", b"0")
@@ -473,7 +472,7 @@ async fn can_consume_multiply() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_consume_multiply").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -487,7 +486,7 @@ async fn can_consume_multiply() {
         assert_eq!(entry.map(|e| e.data), Some(b"0".to_vec()));
     }
     {
-        let (client, conn) = connect("can_consume_multiply").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -495,7 +494,7 @@ async fn can_consume_multiply() {
         assert_eq!(entry.map(|e| e.data), Some(b"1".to_vec()));
     }
     {
-        let (client, conn) = connect("can_consume_multiply").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "two")
             .await
             .expect("consumer");
@@ -506,7 +505,7 @@ async fn can_consume_multiply() {
         assert_eq!(entry.map(|e| e.data), Some(b"0".to_vec()));
     }
     {
-        let (client, conn) = connect("can_consume_multiply").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "two")
             .await
             .expect("consumer");
@@ -518,20 +517,17 @@ async fn can_consume_multiply() {
 #[tokio::test]
 async fn producing_concurrently_should_never_leave_holes() {
     env_logger::try_init().unwrap_or(());
-    setup("producing_concurrently_should_never_leave_holes").await;
+    let schema = "producing_concurrently_should_never_leave_holes";
+    setup(schema).await;
 
-    let (mut client1, conn) = connect("producing_concurrently_should_never_leave_holes")
-        .await
-        .expect("connect");
+    let (mut client1, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     let b1 = pg_queue::batch(&mut client1).await.expect("batch b1");
     let v = b1.produce(b"key", b"first").await.expect("produce 1");
 
     {
-        let (mut client2, conn) = connect("producing_concurrently_should_never_leave_holes")
-            .await
-            .expect("connect");
+        let (mut client2, conn) = connect(schema).await.expect("connect");
         tokio::spawn(conn);
 
         let b2 = pg_queue::batch(&mut client2).await.expect("batch b2");
@@ -541,9 +537,7 @@ async fn producing_concurrently_should_never_leave_holes() {
 
     let observations_a = {
         let mut observations = Vec::new();
-        let (client, conn) = connect("producing_concurrently_should_never_leave_holes")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "a")
             .await
             .expect("consumer");
@@ -557,9 +551,7 @@ async fn producing_concurrently_should_never_leave_holes() {
 
     let observations_b = {
         let mut observations = Vec::new();
-        let (client, conn) = connect("producing_concurrently_should_never_leave_holes")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "b")
             .await
             .expect("consumer");
@@ -591,11 +583,10 @@ async fn producing_concurrently_should_never_leave_holes() {
 #[tokio::test]
 async fn can_list_zero_consumer_offsets() {
     env_logger::try_init().unwrap_or(());
-    setup("can_list_zero_consumer_offsets").await;
+    let schema = "can_list_zero_consumer_offsets";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_list_zero_consumer_offsets")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     pg_queue::produce(&mut client, b"key", b"0")
@@ -605,9 +596,7 @@ async fn can_list_zero_consumer_offsets() {
         .await
         .expect("produce");
 
-    let (client, conn) = connect("can_list_zero_consumer_offsets")
-        .await
-        .expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
 
     let mut cons = pg_queue::Consumer::new(conn, client, "one")
         .await
@@ -619,9 +608,10 @@ async fn can_list_zero_consumer_offsets() {
 #[tokio::test]
 async fn can_list_consumer_offset() {
     env_logger::try_init().unwrap_or(());
-    setup("can_list_consumer_offset").await;
+    let schema = "can_list_consumer_offset";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_list_consumer_offset").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -632,7 +622,7 @@ async fn can_list_consumer_offset() {
 
     let entry;
     {
-        let (client, conn) = connect("can_list_consumer_offset").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -643,7 +633,7 @@ async fn can_list_consumer_offset() {
         cons.commit_upto(&entry).await.expect("commit");
     }
 
-    let (client, conn) = connect("can_list_consumer_offset").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "one")
         .await
         .expect("consumer");
@@ -655,9 +645,10 @@ async fn can_list_consumer_offset() {
 #[tokio::test]
 async fn can_list_consumer_offsets() {
     env_logger::try_init().unwrap_or(());
-    setup("can_list_consumer_offsets").await;
+    let schema = "can_list_consumer_offsets";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_list_consumer_offsets").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -667,7 +658,7 @@ async fn can_list_consumer_offsets() {
         .expect("produce");
 
     let one = {
-        let (client, conn) = connect("can_list_consumer_offsets").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -680,7 +671,7 @@ async fn can_list_consumer_offsets() {
     };
 
     let two = {
-        let (client, conn) = connect("can_list_consumer_offsets").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "two")
             .await
             .expect("consumer");
@@ -694,7 +685,7 @@ async fn can_list_consumer_offsets() {
     expected.insert("one".to_string(), one.version);
     expected.insert("two".to_string(), two.version);
 
-    let (client, conn) = connect("can_list_consumer_offsets").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "two")
         .await
         .expect("consumer");
@@ -705,9 +696,10 @@ async fn can_list_consumer_offsets() {
 #[tokio::test]
 async fn can_discard_entries() {
     env_logger::try_init().unwrap_or(());
-    setup("can_discard_entries").await;
+    let schema = "can_discard_entries";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_discard_entries").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -717,7 +709,7 @@ async fn can_discard_entries() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_discard_entries").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -729,7 +721,7 @@ async fn can_discard_entries() {
     }
 
     {
-        let (client, conn) = connect("can_discard_entries").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "cleaner")
             .await
             .expect("consumer");
@@ -738,7 +730,7 @@ async fn can_discard_entries() {
     }
 
     {
-        let (client, conn) = connect("can_discard_entries").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "two")
             .await
             .expect("consumer");
@@ -750,9 +742,10 @@ async fn can_discard_entries() {
 #[tokio::test]
 async fn can_discard_on_empty() {
     env_logger::try_init().unwrap_or(());
-    setup("can_discard_on_empty").await;
+    let schema = "can_discard_on_empty";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_discard_on_empty").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     {
         let mut cons = pg_queue::Consumer::new(conn, client, "cleaner")
             .await
@@ -766,9 +759,10 @@ async fn can_discard_on_empty() {
 #[tokio::test]
 async fn can_discard_consumed() {
     env_logger::try_init().unwrap_or(());
-    setup("can_discard_consumed").await;
+    let schema = "can_discard_consumed";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_discard_consumed").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -778,7 +772,7 @@ async fn can_discard_consumed() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_discard_consumed").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -791,7 +785,7 @@ async fn can_discard_consumed() {
     }
 
     {
-        let (client, conn) = connect("can_discard_consumed").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "cleaner")
             .await
             .expect("consumer");
@@ -804,7 +798,7 @@ async fn can_discard_consumed() {
     }
 
     {
-        let (client, conn) = connect("can_discard_consumed").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "two")
             .await
             .expect("consumer");
@@ -816,11 +810,10 @@ async fn can_discard_consumed() {
 #[tokio::test]
 async fn can_discard_consumed_on_empty() {
     env_logger::try_init().unwrap_or(());
-    setup("can_discard_consumed_on_empty").await;
+    let schema = "can_discard_consumed_on_empty";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_discard_consumed_on_empty")
-        .await
-        .expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     {
         let mut cons = pg_queue::Consumer::new(conn, client, "cleaner")
             .await
@@ -832,16 +825,17 @@ async fn can_discard_consumed_on_empty() {
 #[tokio::test]
 async fn can_discard_after_written() {
     env_logger::try_init().unwrap_or(());
-    setup("can_discard_after_written").await;
+    let schema = "can_discard_after_written";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_discard_after_written").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     let v = pg_queue::produce(&mut client, b"key", b"0")
         .await
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_discard_after_written").await.expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "cleaner")
             .await
             .expect("consumer");
@@ -857,11 +851,10 @@ async fn can_discard_after_written() {
 #[tokio::test]
 async fn can_discard_consumed_without_losing_entries() {
     env_logger::try_init().unwrap_or(());
-    setup("can_discard_consumed_without_losing_entries").await;
+    let schema = "can_discard_consumed_without_losing_entries";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_discard_consumed_without_losing_entries")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     let _ = pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -874,9 +867,7 @@ async fn can_discard_consumed_without_losing_entries() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_discard_consumed_without_losing_entries")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -890,9 +881,7 @@ async fn can_discard_consumed_without_losing_entries() {
     }
 
     {
-        let (client, conn) = connect("can_discard_consumed_without_losing_entries")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "two")
             .await
             .expect("consumer");
@@ -904,9 +893,7 @@ async fn can_discard_consumed_without_losing_entries() {
     }
 
     {
-        let (client, conn) = connect("can_discard_consumed_without_losing_entries")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "cleaner")
             .await
             .expect("consumer");
@@ -915,9 +902,7 @@ async fn can_discard_consumed_without_losing_entries() {
     }
 
     {
-        let (client, conn) = connect("can_discard_consumed_without_losing_entries")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "one")
             .await
             .expect("consumer");
@@ -929,11 +914,10 @@ async fn can_discard_consumed_without_losing_entries() {
 #[tokio::test]
 async fn can_remove_consumer_offset() {
     env_logger::try_init().unwrap_or(());
-    setup("can_remove_consumer_offset").await;
+    let schema = "can_remove_consumer_offset";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("can_remove_consumer_offset")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -946,9 +930,7 @@ async fn can_remove_consumer_offset() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("can_remove_consumer_offset")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -962,18 +944,14 @@ async fn can_remove_consumer_offset() {
     }
 
     {
-        let (client, conn) = connect("can_remove_consumer_offset")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
         let _ = cons.clear_offset().await.expect("clear_offset");
     }
     {
-        let (client, conn) = connect("can_remove_consumer_offset")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -985,11 +963,10 @@ async fn can_remove_consumer_offset() {
 #[tokio::test]
 async fn removing_non_consumer_is_noop() {
     env_logger::try_init().unwrap_or(());
-    setup("removing_non_consumer_is_noop").await;
+    let schema = "removing_non_consumer_is_noop";
+    setup(schema).await;
 
-    let (mut client, conn) = connect("removing_non_consumer_is_noop")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"0")
         .await
@@ -1002,9 +979,7 @@ async fn removing_non_consumer_is_noop() {
         .expect("produce");
 
     {
-        let (client, conn) = connect("removing_non_consumer_is_noop")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -1015,18 +990,14 @@ async fn removing_non_consumer_is_noop() {
     }
 
     {
-        let (client, conn) = connect("removing_non_consumer_is_noop")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
         cons.clear_offset().await.expect("clear_offset");
     }
     {
-        let (client, conn) = connect("removing_non_consumer_is_noop")
-            .await
-            .expect("connect");
+        let (client, conn) = connect(schema).await.expect("connect");
         let mut cons = pg_queue::Consumer::new(conn, client, "default")
             .await
             .expect("consumer");
@@ -1038,11 +1009,10 @@ async fn removing_non_consumer_is_noop() {
 #[tokio::test]
 async fn can_produce_consume_with_wait() {
     env_logger::try_init().unwrap_or(());
-    setup("can_produce_consume_with_wait").await;
+    let schema = "can_produce_consume_with_wait";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_produce_consume_with_wait")
-        .await
-        .expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
@@ -1054,9 +1024,7 @@ async fn can_produce_consume_with_wait() {
 
     thread::sleep(time::Duration::from_millis(5));
     debug!("Producing");
-    let (mut client, conn) = connect("can_produce_consume_with_wait")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     pg_queue::produce(&mut client, b"key", b"42")
         .await
@@ -1075,14 +1043,15 @@ async fn can_produce_consume_with_wait() {
 async fn can_read_timestamp() {
     env_logger::try_init().unwrap_or(());
     let start = chrono::Utc::now();
-    setup("can_read_timestamp").await;
+    let schema = "can_read_timestamp";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_read_timestamp").await.expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
 
-    let (mut client, conn) = connect("can_read_timestamp").await.expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
     let v = pg_queue::produce(&mut client, b"foo", b"42")
         .await
@@ -1112,18 +1081,15 @@ async fn can_read_timestamp() {
 #[tokio::test]
 async fn can_batch_produce_concurrently() {
     env_logger::try_init().unwrap_or(());
-    setup("can_batch_produce_concurrently").await;
+    let schema = "can_batch_produce_concurrently";
+    setup(schema).await;
 
-    let (client, conn) = connect("can_batch_produce_concurrently")
-        .await
-        .expect("connect");
+    let (client, conn) = connect(schema).await.expect("connect");
     let mut cons = pg_queue::Consumer::new(conn, client, "default")
         .await
         .expect("consumer");
 
-    let (mut client, conn) = connect("can_batch_produce_concurrently")
-        .await
-        .expect("connect");
+    let (mut client, conn) = connect(schema).await.expect("connect");
     tokio::spawn(conn);
 
     let batch = pg_queue::batch(&mut client).await.expect("batch");


### PR DESCRIPTION
This is useful if we ever need to restore from a backup to a new instance.