### PR TITLE
Revert "Rewind to tokio 0.2 so nrod can be consistent for now."

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.8"
-tokio-postgres = { version = "0.5.2", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7.0", features = ["with-chrono-0_4"] }
 chrono = "0.4.7"
 thiserror = "1.0.9"
-tokio = { version = "0.2.24", features = ["sync", "time", "rt-core"] }
+tokio = { version = "1.0.1", features = ["sync", "rt"] }
 futures = "0.3.4"
 futures-util = "0.3.4"
-tokio-util = "0.4.0"
+tokio-util = "0.6.0"
 
 [dev-dependencies]
 env_logger = "0.8.1"
-tokio = { version = "0.2.24", features = ["macros"] }
+tokio = { version = "1.0.1", features = ["macros", "rt"] }
 anyhow = "1.0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::Notify,
-    time::{delay_for, Duration},
+    time::{sleep, Duration},
 };
 use tokio_postgres::{self, AsyncMessage, Client, Connection};
 
@@ -207,7 +207,7 @@ impl Consumer {
                 AsyncMessage::Notice(err) => info!("Db notice: {}", err),
                 AsyncMessage::Notification(n) => {
                     trace!("Received notification: {:?}", n);
-                    notify.notify();
+                    notify.notify_one();
                 }
                 _ => trace!("Other message received"),
             }
@@ -324,7 +324,7 @@ impl Consumer {
                 backoff,
                 pause
             );
-            delay_for(pause).await;
+            sleep(pause).await;
         }
 
         Ok(())


### PR DESCRIPTION
Reverts cstorey/pg-queue#34

Just have this on another branch, since warp on tokio 1.0 looks about ready to ship.