### PR TITLE
Make it easier to create a consumer.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ impl Consumer {
         Self::new(conn, client, name).await
     }
 
-    pub async fn new<
+    async fn new<
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
         T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     >(

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -83,9 +83,8 @@ async fn can_produce_one() {
     let schema = "can_produce_one";
     let pg_config = load_pg_config(schema).expect("pg-config");
     setup(schema).await;
-    let (client, conn) = connect(&pg_config).await.expect("connect");
 
-    let mut cons = pg_queue::Consumer::new(conn, client, "default")
+    let mut cons = pg_queue::Consumer::connect(&pg_config, NoTls, "default")
         .await
         .expect("consumer");
 

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -54,6 +54,7 @@ async fn configure_schema(client: &mut Client, schema: &str) -> Result<()> {
 fn load_pg_config(schema: &str) -> Result<Config> {
     let url = env::var("POSTGRES_URL").unwrap_or_else(|_| DEFAULT_URL.to_string());
     let mut config: Config = url.parse()?;
+    debug!("Use schema name: {}", schema);
 
     config.options(&format!("-csearch_path={}", schema));
 
@@ -67,7 +68,6 @@ async fn connect(
     Connection<tokio_postgres::Socket, tokio_postgres::tls::NoTlsStream>,
 )> {
     let config = load_pg_config(schema)?;
-    debug!("Use schema name: {}", schema);
 
     let (client, conn) = config.connect(NoTls).await?;
     Ok((client, conn))

--- a/tests/prodcons.rs
+++ b/tests/prodcons.rs
@@ -67,20 +67,9 @@ async fn connect(
     Connection<tokio_postgres::Socket, tokio_postgres::tls::NoTlsStream>,
 )> {
     let config = load_pg_config(schema)?;
-
     debug!("Use schema name: {}", schema);
-    let (client, mut conn) = config.connect(NoTls).await?;
 
-    tokio::select! {
-        res = (&mut conn) => panic!("Connection exited? {:?}", res),
-
-        rowsp = client.query("select pg_backend_pid()", &[]) => {
-            let rows = rowsp.expect("rows");
-            let pid : i32 = rows.get(0).expect("some row").get(0);
-            info!("Connected to backend:{:?}", pid);
-        }
-    }
-
+    let (client, conn) = config.connect(NoTls).await?;
     Ok((client, conn))
 }
 


### PR DESCRIPTION
Because always need to pass in both the `client` and `conn` objects, we might as well just add a convenience function to construct it from a postgres config object.