### PR TITLE
Ensure we can use the indexes when ordering rows in queries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ static INSERT_ROW_SQL: &str =
     "INSERT INTO logs (epoch, key, meta, body) values($1, $2, $3, $4) RETURNING epoch, tx_id as tx_position, id as position";
 static SAMPLE_HEAD: &str = "\
     SELECT epoch, tx_id, txid_current() as current_tx_id
-    FROM logs ORDER BY (epoch, tx_id) desc
+    FROM logs ORDER BY epoch desc, tx_id desc
     LIMIT 1";
 static CONSUMER_EPOCHS: &str =
     "SELECT epoch, tx_position as tx_id, txid_current() as current_tx_id FROM log_consumer_positions ORDER BY epoch DESC LIMIT 1";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ static FETCH_NEXT_ROW: &str = "\
     FROM logs
     WHERE (epoch, tx_id, id) > ($1, $2, $3)
     AND (epoch, tx_id) < ($4, txid_snapshot_xmin(txid_current_snapshot()))
-    ORDER BY (epoch, tx_id, id)
+    ORDER BY epoch asc, tx_id asc, id asc
     LIMIT $5";
 static IS_VISIBLE: &str = "\
     WITH snapshot as (


### PR DESCRIPTION
Apparently the optimiser isn't able to push ordering constraints through building a tuple in our ordering constraints, so let's not do that.